### PR TITLE
Reveal secret Monitoring site

### DIFF
--- a/acoustid_web/apps/main/templates/base.html
+++ b/acoustid_web/apps/main/templates/base.html
@@ -57,6 +57,7 @@
         <p>
           <a href="{% url "contact" %}">Contact</a> <span class="has-text-grey-light">|</span>
           <a href="https://blog.acoustid.org/">Blog</a> <span class="has-text-grey-light">|</span>
+          <a href="//monitoring.acoustid.org">Monitoring</a> <span class="has-text-grey-light">|</span>
           <a href="https://twitter.com/acoustid">Twitter</a> <span class="has-text-grey-light">|</span>
           <a href="https://www.facebook.com/acoustid">Facebook</a>
         </p>


### PR DESCRIPTION
> https://community.metabrainz.org/t/something-wrong-with-acoustid-server-again/654927/94?u=jesus2099
>
> I was wondering where those graphs were coming from and then I eventually found a post by [@InvisibleMan78](https://community.metabrainz.org/u/invisibleman78) mentioning [monitoring.acoustid.org](https://monitoring.acoustid.org/).
> Funny I didn’t find it on OHP: [acoustid.org/stats](https://acoustid.org/stats).

I eventually did not find a nice place in /stats and it's an external site.
So I added it in the footer, with the other external links.